### PR TITLE
Add DF to compilation script and move utility functions.

### DIFF
--- a/templates/_CoqProject
+++ b/templates/_CoqProject
@@ -34,6 +34,9 @@ single_copy/coupling.v
 multicopy/multicopy.v
 multicopy/multicopy_util.v
 multicopy/multicopy_client_level.v
+multicopy/multicopy_df.v
+multicopy/multicopy_df_upsert.v
+multicopy/multicopy_df_search.v
 multicopy/multicopy_lsm.v
 multicopy/multicopy_lsm_util.v
 multicopy/multicopy_lsm_search.v

--- a/templates/multicopy/multicopy_lsm_util.v
+++ b/templates/multicopy/multicopy_lsm_util.v
@@ -11,14 +11,14 @@ Require Export auth_ext multicopy_lsm.
 
 Section multicopy_lsm_util.
   Context {Σ} `{!heapG Σ, !multicopyG Σ, !multicopy_lsmG Σ}.
-  Notation iProp := (iProp Σ).  
+  Notation iProp := (iProp Σ).
   Local Notation "m !1 i" := (nzmap_total_lookup i m) (at level 20).
 
   (** Useful lemmas *)
 
-  Global Instance HnP_t_laterable (r n: Node) γ_t lc T : 
-              Laterable (if decide (n = r) 
-                         then own γ_t (●{1 / 2} MaxNat T) ∗ clock lc T 
+  Global Instance HnP_t_laterable (r n: Node) γ_t lc T :
+              Laterable (if decide (n = r)
+                         then own γ_t (●{1 / 2} MaxNat T) ∗ clock lc T
                          else True)%I.
   Proof.
     destruct (decide (n = r)); apply timeless_laterable; apply _.
@@ -34,18 +34,18 @@ Section multicopy_lsm_util.
     apply gset_included in H'.
     iPureIntro. set_solver.
   Qed.
-  
-  Lemma inFP_domm_glob γ_t γ_I γ_J γ_f γ_gh r T hγ I J n : 
+
+  Lemma inFP_domm_glob γ_t γ_I γ_J γ_f γ_gh r T hγ I J n :
     inFP γ_f n -∗ global_state γ_t γ_I γ_J γ_f γ_gh r T hγ I J -∗ ⌜n ∈ domm I⌝.
   Proof.
     iIntros "#FP_n Hglob".
-    iDestruct "Hglob" as "(Ht & HI & Out_I & HJ 
+    iDestruct "Hglob" as "(Ht & HI & Out_I & HJ
             & Out_J & Inf_J & Hf & Hγ & FP_r & domm_IJ & domm_Iγ)".
     iPoseProof (inFP_domm with "[$FP_n] [$]") as "%".
     by iPureIntro.
   Qed.
-  
-  Lemma own_alloc_set (S: gset K): True ==∗ 
+
+  Lemma own_alloc_set (S: gset K): True ==∗
           ∃ (γ: gmap K gname), ([∗ set] k ∈ S, own (γ !!! k) (● (MaxNat 0))).
   Proof.
     iIntros "_".
@@ -54,29 +54,29 @@ Section multicopy_lsm_util.
     - iMod (own_alloc (● (MaxNat 0))) as (γs)"H'".
       { rewrite auth_auth_valid. try done. }
       iDestruct "IH" as ">IH".
-      iDestruct "IH" as (γ)"IH". 
+      iDestruct "IH" as (γ)"IH".
       iModIntro. iExists (<[s := γs]> γ).
       rewrite (big_sepS_delete _ ({[s]} ∪ S) s); last by set_solver.
       iSplitL "H'". by rewrite lookup_total_insert.
       assert (({[s]} ∪ S) ∖ {[s]} = S) as HS. set_solver.
-      rewrite HS. 
-      iApply (big_sepS_mono 
+      rewrite HS.
+      iApply (big_sepS_mono
                   (λ y, own (γ !!! y) (● {| max_nat_car := 0 |}) )%I
                   (λ y, own (<[s:=γs]> γ !!! y) (● {| max_nat_car := 0 |}))%I
                   S); try done.
       intros k k_in_S. iFrame. iIntros "H'".
-      rewrite lookup_total_insert_ne; last by set_solver. 
+      rewrite lookup_total_insert_ne; last by set_solver.
       done.
-      (* No idea what is happening here *) 
+      (* No idea what is happening here *)
       Unshelve. exact (∅: gmap K gname).
   Qed.
 
 
-  Lemma ghost_heap_sync γ_gh n γ_en γ_cn γ_qn γ_cirn 
-                                      γ_en' γ_cn' γ_qn' γ_cirn' : 
-    own γ_gh (◯ {[n := ghost_loc γ_en γ_cn γ_qn γ_cirn]}) 
-      -∗ own γ_gh (◯ {[n := ghost_loc γ_en' γ_cn' γ_qn' γ_cirn']}) 
-          -∗ ⌜γ_en = γ_en'⌝ ∗ ⌜γ_cn = γ_cn'⌝ 
+  Lemma ghost_heap_sync γ_gh n γ_en γ_cn γ_qn γ_cirn
+                                      γ_en' γ_cn' γ_qn' γ_cirn' :
+    own γ_gh (◯ {[n := ghost_loc γ_en γ_cn γ_qn γ_cirn]})
+      -∗ own γ_gh (◯ {[n := ghost_loc γ_en' γ_cn' γ_qn' γ_cirn']})
+          -∗ ⌜γ_en = γ_en'⌝ ∗ ⌜γ_cn = γ_cn'⌝
               ∗ ⌜γ_qn = γ_qn'⌝ ∗ ⌜γ_cirn = γ_cirn'⌝.
   Proof.
     iIntros "H1 H2". iCombine "H1" "H2" as "H".
@@ -90,29 +90,29 @@ Section multicopy_lsm_util.
     by iPureIntro.
   Qed.
 
-  Lemma ghost_heap_update γ_gh (hγ: gmap Node per_node_gl) n 
+  Lemma ghost_heap_update γ_gh (hγ: gmap Node per_node_gl) n
                                 γ_en γ_cn γ_qn γ_cirn :
-    ⌜n ∉ dom (gset Node) hγ⌝ -∗ 
-          own γ_gh (● hγ) ==∗ 
+    ⌜n ∉ dom (gset Node) hγ⌝ -∗
+          own γ_gh (● hγ) ==∗
             own γ_gh (● <[n := ghost_loc γ_en γ_cn γ_qn γ_cirn]> hγ)
           ∗ own γ_gh (◯ {[n := ghost_loc γ_en γ_cn γ_qn γ_cirn]}).
   Proof.
     iIntros "%". rename H into n_notin_hγ.
     iIntros "Hown". set (<[ n := ghost_loc γ_en γ_cn γ_qn γ_cirn ]> hγ) as hγ'.
-    iDestruct (own_update _ _ 
+    iDestruct (own_update _ _
         (● hγ' ⋅ ◯ {[ n := ghost_loc γ_en γ_cn γ_qn γ_cirn ]})
                with "Hown") as "Hown".
-    { apply auth_update_alloc. 
+    { apply auth_update_alloc.
       rewrite /hγ'.
       apply alloc_local_update; last done.
       by rewrite <-not_elem_of_dom. }
     iMod (own_op with "Hown") as "[Ht● Ht◯]".
     iModIntro. iFrame.
-  Qed.    
+  Qed.
 
-  Lemma frac_eq γ_e γ_c γ_q es Cn Qn es' Cn' Qn' : 
+  Lemma frac_eq γ_e γ_c γ_q es Cn Qn es' Cn' Qn' :
               frac_ghost_state γ_e γ_c γ_q es Cn Qn -∗
-                  frac_ghost_state γ_e γ_c γ_q es' Cn' Qn' -∗ 
+                  frac_ghost_state γ_e γ_c γ_q es' Cn' Qn' -∗
                     ⌜es = es'⌝ ∗ ⌜Cn = Cn'⌝ ∗ ⌜Qn = Qn'⌝.
   Proof.
     iIntros "H1 H2". unfold frac_ghost_state.
@@ -126,52 +126,52 @@ Section multicopy_lsm_util.
     apply frac_agree_op_valid in Hc. destruct Hc as [_ Hc].
     apply frac_agree_op_valid in Hq. destruct Hq as [_ Hq].
     apply leibniz_equiv_iff in Hes.
-    apply leibniz_equiv_iff in Hc. 
+    apply leibniz_equiv_iff in Hc.
     apply leibniz_equiv_iff in Hq.
-    iPureIntro. repeat split; try done.   
+    iPureIntro. repeat split; try done.
   Qed.
 
-  Lemma frac_update γ_e γ_c γ_q es Cn Qn es' Cn' Qn' : 
-              frac_ghost_state γ_e γ_c γ_q es Cn Qn ∗ 
-                 frac_ghost_state γ_e γ_c γ_q es Cn Qn ==∗ 
-                      frac_ghost_state γ_e γ_c γ_q es' Cn' Qn' ∗ 
+  Lemma frac_update γ_e γ_c γ_q es Cn Qn es' Cn' Qn' :
+              frac_ghost_state γ_e γ_c γ_q es Cn Qn ∗
+                 frac_ghost_state γ_e γ_c γ_q es Cn Qn ==∗
+                      frac_ghost_state γ_e γ_c γ_q es' Cn' Qn' ∗
                         frac_ghost_state γ_e γ_c γ_q es' Cn' Qn'.
   Proof.
-    iIntros "(H1 & H2)". 
+    iIntros "(H1 & H2)".
     iDestruct "H1" as "(H1_es & H1_c & H1_q)".
     iDestruct "H2" as "(H2_es & H2_c & H2_q)".
-    iCombine "H1_es H2_es" as "Hes". 
-    iEval (rewrite <-frac_agree_op) in "Hes". 
-    iEval (rewrite Qp_half_half) in "Hes". 
-    iCombine "H1_c H2_c" as "Hc". 
-    iEval (rewrite <-frac_agree_op) in "Hc". 
-    iEval (rewrite Qp_half_half) in "Hc". 
-    iCombine "H1_q H2_q" as "Hq". 
-    iEval (rewrite <-frac_agree_op) in "Hq". 
+    iCombine "H1_es H2_es" as "Hes".
+    iEval (rewrite <-frac_agree_op) in "Hes".
+    iEval (rewrite Qp_half_half) in "Hes".
+    iCombine "H1_c H2_c" as "Hc".
+    iEval (rewrite <-frac_agree_op) in "Hc".
+    iEval (rewrite Qp_half_half) in "Hc".
+    iCombine "H1_q H2_q" as "Hq".
+    iEval (rewrite <-frac_agree_op) in "Hq".
     iEval (rewrite Qp_half_half) in "Hq".
-    iMod ((own_update (γ_e) (to_frac_agree 1 es) 
+    iMod ((own_update (γ_e) (to_frac_agree 1 es)
                   (to_frac_agree 1 es')) with "[$Hes]") as "Hes".
     { apply cmra_update_exclusive. 
       unfold valid, cmra_valid. simpl. unfold prod_valid_instance.
       split; simpl; try done. }
     iEval (rewrite <-Qp_half_half) in "Hes".
-    iEval (rewrite frac_agree_op) in "Hes".  
-    iDestruct "Hes" as "(H1_es & H2_es)".            
-    iMod ((own_update (γ_c) (to_frac_agree 1 Cn) 
+    iEval (rewrite frac_agree_op) in "Hes".
+    iDestruct "Hes" as "(H1_es & H2_es)".
+    iMod ((own_update (γ_c) (to_frac_agree 1 Cn)
                   (to_frac_agree 1 Cn')) with "[$Hc]") as "Hc".
     { apply cmra_update_exclusive. 
       unfold valid, cmra_valid. simpl. unfold prod_valid_instance.
       split; simpl; try done. }
     iEval (rewrite <-Qp_half_half) in "Hc".
-    iEval (rewrite frac_agree_op) in "Hc".  
+    iEval (rewrite frac_agree_op) in "Hc".
     iDestruct "Hc" as "(H1_c & H2_c)".
-    iMod ((own_update (γ_q) (to_frac_agree 1 Qn) 
+    iMod ((own_update (γ_q) (to_frac_agree 1 Qn)
                   (to_frac_agree 1 Qn')) with "[$Hq]") as "Hq".
     { apply cmra_update_exclusive. 
       unfold valid, cmra_valid. simpl. unfold prod_valid_instance.
       split; simpl; try done. }
     iEval (rewrite <-Qp_half_half) in "Hq".
-    iEval (rewrite frac_agree_op) in "Hq".  
+    iEval (rewrite frac_agree_op) in "Hq".
     iDestruct "Hq" as "(H1_q & H2_q)".
     iModIntro. iFrame.
   Qed.
@@ -199,7 +199,7 @@ Section multicopy_lsm_util.
       { rewrite /(● I' ⋅ ◯ I_n'). unfold cmra_op.
         simpl. unfold view_op_instance. simpl.
         assert (ε ⋅ I_n' = I_n') as H'. by rewrite left_id.
-        rewrite H'. unfold op, cmra_op. by simpl. }   
+        rewrite H'. unfold op, cmra_op. by simpl. }
       by iEval (rewrite H').
   Qed.
 
@@ -226,9 +226,9 @@ Section multicopy_lsm_util.
       { rewrite /(● I' ⋅ ◯ I_n'). unfold cmra_op.
         simpl. unfold view_op_instance. simpl.
         assert (ε ⋅ I_n' = I_n') as H'. by rewrite left_id.
-        rewrite H'. unfold op, cmra_op. by simpl. }   
+        rewrite H'. unfold op, cmra_op. by simpl. }
       by iEval (rewrite H').
-  Qed.    
+  Qed.
 
   Lemma dom_lookup (C: gmap K nat) k :
         C !! k ≠ None → k ∈ dom (gset K) C.
@@ -237,16 +237,16 @@ Section multicopy_lsm_util.
     rewrite elem_of_dom. rewrite Hcnk.
     by exists n. done.
   Qed.
-  
+
   Definition map_subset (S: gset K) (C: gmap K nat) :=
               let f := λ a s', s' ∪ {[(a, C !!! a)]} in
-                        set_fold f (∅: gset KT) S.          
+                        set_fold f (∅: gset KT) S.
 
-  Definition map_restriction (S: gset K) (C: gmap K nat) := 
+  Definition map_restriction (S: gset K) (C: gmap K nat) :=
               let f := λ a m, <[a := C !!! a ]> m in
                         set_fold f (∅: gmap K nat) S.
-                        
-  
+
+
   Lemma lookup_map_restriction S (C: gmap K nat) (k: K):
               k ∈ S → map_restriction S C !! k = Some (C !!! k).
   Proof.
@@ -285,24 +285,24 @@ Section multicopy_lsm_util.
         rewrite H'. rewrite H''. set_solver.
         assert ((kx', tx') ∈ r) as Hkt.
         apply HP. split; try done.
-        set_solver.       
-  Qed.              
+        set_solver.
+  Qed.
 
   Lemma map_restriction_dom S C :
               dom (gset K) (map_restriction S C) = S.
   Proof.
     set (P := λ (m: gmap K nat) (X: gset K), dom (gset K) m = X).
     apply (set_fold_ind_L P); try done.
-    - unfold P; set_solver. 
-    - intros x X r Hx HP. unfold P. unfold P in HP. 
+    - unfold P; set_solver.
+    - intros x X r Hx HP. unfold P. unfold P in HP.
       apply leibniz_equiv. rewrite dom_insert.
       rewrite HP. done.
-  Qed.            
+  Qed.
 
   Lemma map_of_set_lookup_some_aux (H: gset KT) k :
           (∀ t, (k,t) ∉ H) ∨ (∃ T, (k, T) ∈ H ∧ (∀ t', (k,t') ∈ H → t' ≤ T)).
   Proof.
-    set (P := λ (X: gset KT), (∀ t, (k,t) ∉ X) ∨ 
+    set (P := λ (X: gset KT), (∀ t, (k,t) ∉ X) ∨
                   (∃ T, (k, T) ∈ X ∧ (∀ t', (k,t') ∈ X → t' ≤ T))).
     apply (set_ind_L P); try done.
     - unfold P. left. intros t. set_solver.
@@ -315,7 +315,7 @@ Section multicopy_lsm_util.
           intros H''. assert ((k,t) ∈ X).
           set_solver. pose proof H' t as H'.
           done.
-        * right. destruct H' as [T H']. 
+        * right. destruct H' as [T H'].
           destruct (decide (t' < T)).
           ** exists T. split.
              destruct H' as [H' _].
@@ -323,14 +323,14 @@ Section multicopy_lsm_util.
              rewrite elem_of_union in Hkt'*; intros Hkt'.
              destruct Hkt' as [Hkt' | Hkt'].
              rewrite elem_of_singleton in Hkt'*; intros Hkt'.
-             inversion Hkt'. lia. 
+             inversion Hkt'. lia.
              destruct H' as [_ H'']. apply H''; try done.
           ** exists t'. split. set_solver.
              intros t Hkt'. rewrite elem_of_union in Hkt'*; intros Hkt'.
              destruct Hkt' as [Hkt' | Hkt'].
              rewrite elem_of_singleton in Hkt'*; intros Hkt'.
              inversion Hkt'. lia.
-             destruct H' as [_ H'']. 
+             destruct H' as [_ H''].
              apply (Nat.le_trans _ T _); try lia.
              apply H''. try done.
       + destruct HP as [H' | H'].
@@ -360,9 +360,9 @@ Section multicopy_lsm_util.
       destruct Hkt' as [Hkt' _].
       destruct H' as [H' _].
       pose proof H' T as H'.
-      set_solver.   
+      set_solver.
   Qed.
-  
+
   Lemma map_of_set_lookup_lb H k t :
     (k,t) ∈ H → t ≤ map_of_set H !!! k.
   Proof.
@@ -373,22 +373,22 @@ Section multicopy_lsm_util.
       simpl. apply H'; try done.
     - destruct H' as [H' _].
       pose proof H' t as H'.
-      contradiction.  
-  Qed.   
+      contradiction.
+  Qed.
 
   Lemma set_of_map_member_ne (C: gmap K nat) k :
-            C !! k = None →    
+            C !! k = None →
               ∀ t, (k, t) ∉ set_of_map C.
   Proof.
-    set (P := λ (s: gset KT) (m: gmap K nat), 
-                   m !! k = None → ∀ t, (k, t) ∉ s). 
+    set (P := λ (s: gset KT) (m: gmap K nat),
+                   m !! k = None → ∀ t, (k, t) ∉ s).
     apply (map_fold_ind P); try done.
     intros kx tx m r Hm HP. unfold P.
     unfold P in HP. destruct (decide (kx = k)).
     - subst kx. rewrite lookup_insert. try done.
-    - rewrite lookup_insert_ne; try done. 
-      intros Hm'. pose proof HP Hm' as HP. 
-      intros t. intros Hnot. 
+    - rewrite lookup_insert_ne; try done.
+      intros Hm'. pose proof HP Hm' as HP.
+      intros t. intros Hnot.
       rewrite elem_of_union in Hnot*; intros Hnot.
       destruct Hnot as [Hnot | Hnot].
       + by apply HP in Hnot.
@@ -396,85 +396,36 @@ Section multicopy_lsm_util.
         inversion Hnot. try done.
   Qed.
 
-  Lemma set_of_map_member (C: gmap K nat) k t :
-            C !! k = Some(t) →    
-              (k, t) ∈ set_of_map C.
-  Proof.
-    intros Hc. unfold set_of_map.
-    set (P := λ (s: gset KT) (m: gmap K nat), 
-                  ∀ j x, m !! j = Some x → (j,x) ∈ s). 
-    apply (map_fold_ind P); try done.
-    intros i x m s Hmi Hp. unfold P.
-    intros j x'. destruct (decide (i = j)).
-    - replace j. rewrite lookup_insert. 
-      intros H'; inversion H'. set_solver.
-    - rewrite lookup_insert_ne; try done.
-      pose proof Hp j x' as Hp'. set_solver.
-  Qed.
-
-  Lemma set_of_map_member_rev (C: gmap K nat) k t :
-            (k, t) ∈ set_of_map C → 
-                C !! k = Some(t).
-  Proof.
-    set (P := λ (s: gset KT) (m: gmap K nat), 
-                  ∀ j x, (j,x) ∈ s → m !! j = Some x).
-    apply (map_fold_ind P); try done.
-    intros i x m r Hmi Hp. unfold P.
-    intros j x'. destruct (decide (i = j)).
-    - replace j. rewrite lookup_insert.
-      rewrite elem_of_union. intros [Hr | Hr].
-      unfold P in Hp. pose proof Hp i x' Hr as Hp.
-      rewrite Hp in Hmi. inversion Hmi.
-      assert (x = x') by set_solver. by replace x.              
-    - intros H'. assert ((j,x') ∈ r) as Hj by set_solver.
-      pose proof Hp j x' Hj as Hp.
-      rewrite lookup_insert_ne; try done.
-  Qed.
-
-  Lemma set_of_map_insert_subseteq (C: gmap K nat) k t :
-         set_of_map (<[k := t]> C) ⊆ set_of_map C ∪ {[(k, t)]}.
-  Proof.
-    intros [k' t'] Hkt. destruct (decide (k' = k)).
-    - replace k'. rewrite e in Hkt. 
-      apply set_of_map_member_rev in Hkt.
-      rewrite lookup_insert in Hkt.
-      inversion Hkt. set_solver.
-    - apply set_of_map_member_rev in Hkt.
-      rewrite lookup_insert_ne in Hkt; try done.
-      apply set_of_map_member in Hkt.
-      set_solver.  
-  Qed.          
-
-  Lemma nodePred_nodeShared_eq γ_I γ_J γ_f γ_gh r n 
+  Lemma nodePred_nodeShared_eq γ_I γ_J γ_f γ_gh r n
                                γ_en γ_cn γ_qn γ_cirn
                                γ_en' γ_cn' γ_qn' γ_cirn'
                                es Cn Qn es' Cn' Qn'
                                Bn In Jn H :
         own γ_gh (◯ {[n := ghost_loc γ_en γ_cn γ_qn γ_cirn]}) -∗
           frac_ghost_state γ_en γ_cn γ_qn es Cn Qn -∗
-            nodeShared' γ_I γ_J γ_f γ_gh r n Cn' Qn' H 
+            nodeShared' γ_I γ_J γ_f γ_gh r n Cn' Qn' H
                         γ_en' γ_cn' γ_qn' γ_cirn' es' Bn In Jn -∗
               frac_ghost_state γ_en γ_cn γ_qn es Cn Qn
-              ∗ nodeShared' γ_I γ_J γ_f γ_gh r n Cn Qn H 
+              ∗ nodeShared' γ_I γ_J γ_f γ_gh r n Cn Qn H
                           γ_en γ_cn γ_qn γ_cirn es Bn In Jn
               ∗ ⌜es' = es⌝ ∗ ⌜Cn' = Cn⌝  ∗ ⌜Qn' = Qn⌝.
   Proof.
     iIntros "HnP_gh HnP_frac HnS".
-    iDestruct "HnS" as "(HnS_gh & HnS_frac & HnS_si & HnS_FP 
+    iDestruct "HnS" as "(HnS_gh & HnS_frac & HnS_si & HnS_FP
                         & HnS_cl & HnS_oc & HnS_Bn & HnS_H  & HnS_star & Hφ)".
-    iPoseProof (ghost_heap_sync with "[$HnP_gh] [$HnS_gh]") 
+    iPoseProof (ghost_heap_sync with "[$HnP_gh] [$HnS_gh]")
                               as "(% & % & % & %)".
     subst γ_en'. subst γ_cn'. subst γ_qn'. subst γ_cirn'.
     iPoseProof (frac_eq with "[$HnP_frac] [$HnS_frac]") as "%".
-    destruct H0 as [Hes [Hc Hq]]. 
+    destruct H0 as [Hes [Hc Hq]].
     subst es'. subst Cn'. subst Qn'.
     iFrame. by iPureIntro.
-  Qed.                                        
-  
+  Qed.
+
   (** Lock module **)
 
   Lemma lockNode_spec_high N γ_te γ_he γ_s Prot γ_t γ_I γ_J γ_f γ_gh lc r n:
-    ⊢ mcs_inv N γ_te γ_he γ_s Prot 
+    ⊢ mcs_inv N γ_te γ_he γ_s Prot
                 (Inv_LSM γ_s γ_t γ_I γ_J γ_f γ_gh lc r) -∗
         inFP γ_f n -∗
               <<< True >>>
@@ -484,11 +435,11 @@ Section multicopy_lsm_util.
     iIntros "#mcsInv #FP_n".
     iIntros (Φ) "AU".
     awp_apply (lockNode_spec n).
-    iInv "mcsInv" as (T H) "(mcs_high & >Inv_LSM)". 
+    iInv "mcsInv" as (T H) "(mcs_high & >Inv_LSM)".
     iDestruct "Inv_LSM" as (hγ I J) "(Hglob & Hstar)".
-    iPoseProof (inFP_domm_glob with "[$FP_n] [$Hglob]") as "%". 
+    iPoseProof (inFP_domm_glob with "[$FP_n] [$Hglob]") as "%".
     rename H0 into n_in_I.
-    iEval (rewrite (big_sepS_elem_of_acc (_) (domm I) n); 
+    iEval (rewrite (big_sepS_elem_of_acc (_) (domm I) n);
            last by eauto) in "Hstar".
     iDestruct "Hstar" as "(Hn & Hstar')".
     iDestruct "Hn" as (b Cn Qn) "(HlockR & Hns)".
@@ -515,8 +466,8 @@ Section multicopy_lsm_util.
   Qed.
 
 
-  Lemma nodePred_lockR_true γ_gh γ_t γ_s lc r bn n es Cn Cn' Qn' : 
-    node r n es Cn -∗ 
+  Lemma nodePred_lockR_true γ_gh γ_t γ_s lc r bn n es Cn Cn' Qn' :
+    node r n es Cn -∗
       lockR bn n (nodePred γ_gh γ_t γ_s lc r n Cn' Qn') -∗
         ⌜bn = true⌝.
   Proof.
@@ -525,16 +476,16 @@ Section multicopy_lsm_util.
     iDestruct "Hl_n" as "(Hl & HnP')".
     iDestruct "HnP'" as (? ? ? ? ? ?) "(n' & _)".
     iExFalso. iApply (node_sep_star r n). iFrame.
-  Qed.          
+  Qed.
 
   Lemma lockR_true Cn' Qn' γ_gh γ_t γ_s lc r n Cn Qn:
     lockR true n (nodePred γ_gh γ_t γ_s lc r n Cn Qn) -∗
       lockR true n (nodePred γ_gh γ_t γ_s lc r n Cn' Qn').
   Proof.
     iIntros "(Hl & _)". iFrame.
-  Qed.       
+  Qed.
 
-  Lemma unlockNode_spec_high N γ_te γ_he γ_s Prot γ_t γ_I γ_J γ_f γ_gh lc r 
+  Lemma unlockNode_spec_high N γ_te γ_he γ_s Prot γ_t γ_I γ_J γ_f γ_gh lc r
                                                           n Cn Qn:
     ⊢ mcs_inv N γ_te γ_he γ_s Prot (Inv_LSM γ_s γ_t γ_I γ_J γ_f γ_gh lc r) -∗
         inFP γ_f n -∗ nodePred γ_gh γ_t γ_s lc r n Cn Qn -∗
@@ -546,13 +497,13 @@ Section multicopy_lsm_util.
     awp_apply (unlockNode_spec n).
     iInv "mcsInv" as (T H) "(mcs_high & >Inv_LSM)".
     iDestruct "Inv_LSM" as (hγ I J) "(Hglob & Hstar)".
-    iPoseProof (inFP_domm_glob with "[$FP_n] [$Hglob]") as "%". 
+    iPoseProof (inFP_domm_glob with "[$FP_n] [$Hglob]") as "%".
     rename H0 into n_in_I.
-    iEval (rewrite (big_sepS_elem_of_acc (_) (domm I) n); 
+    iEval (rewrite (big_sepS_elem_of_acc (_) (domm I) n);
            last by eauto) in "Hstar".
     iDestruct "Hstar" as "(Hn & Hstar')".
     iDestruct "Hn" as (b Cn' Qn') "(HlockR & Hns)".
-    iAssert (lockR true n (nodePred γ_gh γ_t γ_s lc r n Cn Qn) 
+    iAssert (lockR true n (nodePred γ_gh γ_t γ_s lc r n Cn Qn)
               ∗ (nodePred γ_gh γ_t γ_s lc r n Cn Qn))%I
       with "[HlockR Hnp]" as "HlockR".
     {
@@ -571,7 +522,7 @@ Section multicopy_lsm_util.
       iExists hγ, I, J. iFrame.
       iPoseProof ("Hstar'" with "[HlockR Hns]") as "Hstar".
       iExists true, Cn', Qn'. iFrame.
-      iFrame. iFrame. 
+      iFrame. iFrame.
     }
     iIntros "HlockR".
     iMod "AU" as "[_ [_ Hclose]]".
@@ -591,7 +542,7 @@ Section multicopy_lsm_util.
       iDestruct "Hns" as (γ_en' γ_cn' γ_qn' γ_cirn' es' Bn' In0 Jn0) "Hns'".
       iPoseProof (nodePred_nodeShared_eq with "[$HnP_gh] [$HnP_frac] [$Hns']")
          as "(HnP_frac & Hns' & % & % & %)".
-      iSplitR "Hns'".                          
+      iSplitR "Hns'".
       - iFrame. iExists γ_en, γ_cn, γ_qn, γ_cirn, esn, T'.
         iFrame "∗#".
       - iExists γ_en, γ_cn, γ_qn, γ_cirn, esn, Bn', In0, Jn0.

--- a/templates/multicopy/multicopy_util.v
+++ b/templates/multicopy/multicopy_util.v
@@ -7,7 +7,7 @@ Require Export multicopy.
 Section multicopy_util.
   Context {Σ} `{!multicopyG Σ}.
   Notation iProp := (iProp Σ).
-  
+
   Lemma MCS_agree γ_te γ_he t H t' H':
     MCS_auth γ_te γ_he t H -∗ MCS γ_te γ_he t' H' -∗ ⌜t = t'⌝ ∗ ⌜H = H'⌝.
   Proof.
@@ -16,15 +16,15 @@ Section multicopy_util.
       as %[<-%Excl_included%leibniz_equiv _]%auth_both_valid_discrete.
     iDestruct (own_valid_2 with "HH● HH'◯")
       as %[<-%Excl_included%leibniz_equiv _]%auth_both_valid_discrete.
-    by iPureIntro.  
-  Qed.    
-        
+    by iPureIntro.
+  Qed.
+
   Lemma map_of_set_lookup_cases H1 k:
         (∃ T, (k, T) ∈ H1 ∧ (∀ t, (k,t) ∈ H1 → t ≤ T) ∧ map_of_set H1 !! k = Some T)
       ∨ ((∀ t, (k,t) ∉ H1) ∧ map_of_set H1 !! k = None).
   Proof.
     set (P := λ (m: gmap K nat) (X: gset KT),
-                (∃ T, (k, T) ∈ X ∧ (∀ t, (k,t) ∈ X → t ≤ T) 
+                (∃ T, (k, T) ∈ X ∧ (∀ t, (k,t) ∈ X → t ≤ T)
                           ∧ m !! k = Some T)
               ∨ ((∀ t, (k,t) ∉ X) ∧ m !! k = None)).
     apply (set_fold_ind_L P); try done.
@@ -37,20 +37,20 @@ Section multicopy_util.
           destruct (decide (T < t')).
           ** exists t'. repeat split; first set_solver.
              intros t. rewrite elem_of_union.
-             intros [Hv | Hv]. assert (t = t') by set_solver. 
+             intros [Hv | Hv]. assert (t = t') by set_solver.
              lia. destruct Hp as [_ [Hp _]].
              pose proof Hp t Hv. lia. simpl.
              assert (m !!! k <= t') as Hm.
              { unfold lookup_total, map_lookup_total.
                destruct Hp as [_ [_ Hp]]. rewrite Hp.
                simpl. lia. }
-             destruct (decide (m !!! k ≤ t')); try done.  
-             by rewrite lookup_insert.      
-          ** assert (t' = T ∨ t' < T) as Ht by lia. clear n. 
+             destruct (decide (m !!! k ≤ t')); try done.
+             by rewrite lookup_insert.
+          ** assert (t' = T ∨ t' < T) as Ht by lia. clear n.
              exists T. destruct Hp as [Hp1 [Hp2 Hp3]].
              repeat split; first set_solver.
              intros t. rewrite elem_of_union.
-             intros [Hv | Hv]. assert (t = t') by set_solver. 
+             intros [Hv | Hv]. assert (t = t') by set_solver.
              lia. pose proof Hp2 t Hv. lia. simpl.
              destruct Ht as [Ht | Ht].
              assert (m !!! k <= t') as Hm.
@@ -61,17 +61,17 @@ Section multicopy_util.
              assert (m !!! k > t') as Hm.
              { unfold lookup_total, map_lookup_total.
                rewrite Hp3. simpl. lia. }
-             destruct (decide (m !!! k ≤ t')); try done.  
+             destruct (decide (m !!! k ≤ t')); try done.
              exfalso. lia.
         * exists t'. simpl. repeat split; first set_solver.
           intros t. rewrite elem_of_union. intros [Hv | Hv].
           assert (t = t') by set_solver. lia.
-          destruct Hp as [Hp _]. 
+          destruct Hp as [Hp _].
           pose proof Hp t as Hp. set_solver.
           assert (m !!! k ≤ t') as Hm.
           { unfold lookup_total, map_lookup_total.
             destruct Hp as [_ Hp]. rewrite Hp. simpl; lia. }
-          destruct (decide (m !!! k ≤ t')); try done.  
+          destruct (decide (m !!! k ≤ t')); try done.
           by rewrite lookup_insert.
       + unfold P. unfold P in Hp.
         destruct Hp as [Hp | Hp].
@@ -79,16 +79,16 @@ Section multicopy_util.
           left. exists T. repeat split; first set_solver.
           intros t Hkt. assert ((k,t) ∈ X) as Hx by set_solver.
           by pose proof Hp2 t Hx.
-          simpl. 
-          destruct (decide (m !!! k' <= t')). 
+          simpl.
+          destruct (decide (m !!! k' <= t')).
           rewrite lookup_insert_ne; try done. done.
         * destruct Hp as [Hp1 Hp2]. right.
-          repeat split; first set_solver. simpl.   
-          destruct (decide (m !!! k' <= t')). 
+          repeat split; first set_solver. simpl.
+          destruct (decide (m !!! k' <= t')).
           rewrite lookup_insert_ne; try done. done.
   Qed.
 
-  Lemma map_of_set_lookup H k T : 
+  Lemma map_of_set_lookup H k T :
         (k, T) ∈ H → (∀ t, (k, t) ∈ H → t ≤ T) →
            map_of_set H !! k = Some T.
   Proof.
@@ -104,7 +104,7 @@ Section multicopy_util.
       pose proof Hp T. set_solver.
   Qed.
 
-  Lemma map_of_set_union_ne H k t k' : 
+  Lemma map_of_set_union_ne H k t k' :
           k' ≠ k → map_of_set (H ∪ {[(k, t)]}) !! k' = map_of_set H !! k'.
   Proof.
     intros Hk.
@@ -119,28 +119,28 @@ Section multicopy_util.
           by pose proof Hu2 T Ht. }
         assert (T' ≤ T) as Ht2.
         { assert ((k', T') ∈ H) as Ht by set_solver.
-          by pose proof Hp2 T' Ht. }  
+          by pose proof Hp2 T' Ht. }
         rewrite Hp3 Hu3. assert (T = T') as Ht by lia.
         by rewrite Ht.
       + destruct Hp as [T [Hp1 [Hp2 Hp3]]].
         destruct Hu as [Hu1 Hu2].
         pose proof Hu1 T as Hu1. set_solver.
     - destruct Hu as [Hu | Hu].
-      + destruct Hp as [Hp1 Hp2].         
+      + destruct Hp as [Hp1 Hp2].
         destruct Hu as [T' [Hu1 [Hu2 Hu3]]].
-        pose proof Hp1 T' as Hp1. set_solver.      
+        pose proof Hp1 T' as Hp1. set_solver.
       + destruct Hp as [Hp1 Hp2].
         destruct Hu as [Hu1 Hu2].
-        by rewrite Hp2 Hu2.    
+        by rewrite Hp2 Hu2.
   Qed.
 
   Lemma map_of_set_insert_eq (C: gmap K nat) k T H :
-        (∀ t, (k, t) ∈ H → t < T) → 
+        (∀ t, (k, t) ∈ H → t < T) →
                   C = map_of_set H →
                  <[k := T]> C = map_of_set (H ∪ {[(k, T)]}).
   Proof.
     intros Hmax Hc. apply map_eq. intros k'.
-    destruct (decide (k' = k)). 
+    destruct (decide (k' = k)).
     - replace k'. rewrite lookup_insert.
       rewrite (map_of_set_lookup _ _ T); try done.
       set_solver. intros t'. rewrite elem_of_union.
@@ -149,6 +149,55 @@ Section multicopy_util.
     - rewrite map_of_set_union_ne; try done.
       rewrite lookup_insert_ne; try done.
       by rewrite Hc.
-  Qed. 
+  Qed.
+
+  Lemma set_of_map_member (C: gmap K nat) k t :
+            C !! k = Some(t) →
+              (k, t) ∈ set_of_map C.
+  Proof.
+    intros Hc. unfold set_of_map.
+    set (P := λ (s: gset KT) (m: gmap K nat),
+                  ∀ j x, m !! j = Some x → (j,x) ∈ s).
+    apply (map_fold_ind P); try done.
+    intros i x m s Hmi Hp. unfold P.
+    intros j x'. destruct (decide (i = j)).
+    - replace j. rewrite lookup_insert.
+      intros H'; inversion H'. set_solver.
+    - rewrite lookup_insert_ne; try done.
+      pose proof Hp j x' as Hp'. set_solver.
+  Qed.
+
+  Lemma set_of_map_member_rev (C: gmap K nat) k t :
+            (k, t) ∈ set_of_map C →
+                C !! k = Some(t).
+  Proof.
+    set (P := λ (s: gset KT) (m: gmap K nat),
+                  ∀ j x, (j,x) ∈ s → m !! j = Some x).
+    apply (map_fold_ind P); try done.
+    intros i x m r Hmi Hp. unfold P.
+    intros j x'. destruct (decide (i = j)).
+    - replace j. rewrite lookup_insert.
+      rewrite elem_of_union. intros [Hr | Hr].
+      unfold P in Hp. pose proof Hp i x' Hr as Hp.
+      rewrite Hp in Hmi. inversion Hmi.
+      assert (x = x') by set_solver. by replace x.
+    - intros H'. assert ((j,x') ∈ r) as Hj by set_solver.
+      pose proof Hp j x' Hj as Hp.
+      rewrite lookup_insert_ne; try done.
+  Qed.
+
+  Lemma set_of_map_insert_subseteq (C: gmap K nat) k t :
+    set_of_map (<[k := t]> C) ⊆ set_of_map C ∪ {[(k, t)]}.
+  Proof.
+    intros [k' t'] Hkt. destruct (decide (k' = k)).
+    - replace k'. rewrite e in Hkt.
+    apply set_of_map_member_rev in Hkt.
+    rewrite lookup_insert in Hkt.
+    inversion Hkt. set_solver.
+    - apply set_of_map_member_rev in Hkt.
+    rewrite lookup_insert_ne in Hkt; try done.
+    apply set_of_map_member in Hkt.
+    set_solver.
+  Qed.
 
 End multicopy_util.

--- a/templates/xp_ecoop21.sh
+++ b/templates/xp_ecoop21.sh
@@ -43,6 +43,7 @@ echo -e "% Module\t\t& Code\t& Proof\t& Total\t& Time" >> $outputfile
 run "Flow Library" "flows/gmap_more flows/ccm flows/flows flows/multiset_flows"
 run "Lock Implementation" "util/auth_ext util/lock util/one_shot_proph util/typed_proph"
 run "Client-level Spec" "multicopy/multicopy multicopy/multicopy_util multicopy/multicopy_client_level"
+run "DF Template" "multicopy/multicopy_df multicopy/multicopy_df_search multicopy/multicopy_df_upsert"
 run "LSM DAG Template" "multicopy/multicopy_lsm multicopy/multicopy_lsm_util multicopy/multicopy_lsm_search multicopy/multicopy_lsm_upsert multicopy/multicopy_lsm_compact"
 
 echo -e "\\hline" >> $outputfile


### PR DESCRIPTION
This pull request does 2 things:

1. Adds DF files to _CoqProject and xp_ecoop21.sh
2. The DF proofs need (I think) to use some set functions from multicopy_lsm_util, namely set_of_map_member, set_of_map_member_rev, set_of_map_member_subseteq.  @eadiet figured out that if multicopy_lsm_util is fully included with Require Export, multicopy_lsm is also fully included, which causes namespace conflicts.  If multicopy_lsm is just referenced with Require, and the functions are referred to by full name, there is a "Cannot satisfy constraints" error relating to not having the Context defined in multicopy_lsm_util available, namely !multicopy_lsmG Σ.  This moves the functions to multicopy_util where they can be included without namespace conflicts in both.